### PR TITLE
Fix compatibility with ComfyUI-Logic

### DIFF
--- a/smZNodes.py
+++ b/smZNodes.py
@@ -752,7 +752,7 @@ def prompt_handler(json_data):
 
             while(True):
                 # Base case: it's a direct value
-                if isinstance(steps_input_value, (int, float, str)):
+                if is_number(steps_input_value):
                     return min(max(1, int(steps_input_value)), 10000)
 
                 # Loop case: it's a reference to another node
@@ -786,6 +786,12 @@ def prompt_handler(json_data):
 
             return False
 
+        def is_number(s):
+            try:
+                float(s)
+                return True
+            except (ValueError, TypeError):
+                return False
 
         # Update each CLIPTextEncode node's steps with the steps from its nearest referencing KSampler node
         for clip_id, node in data.items():


### PR DESCRIPTION
Using smZNodes along with [ComfyUI-Logic](https://github.com/theUpsider/ComfyUI-Logic) throws `ValueError: invalid literal for int() with base 10: 'a != b'` in `prompt_handler` method.
Since not every `str` in node inputs can be parsed into `int`, I believe we should replace `isinstance` with `is_number` check.