### PR TITLE
Negpip support

### DIFF
--- a/modules/sd_hijack_clip.py
+++ b/modules/sd_hijack_clip.py
@@ -5,7 +5,7 @@ import torch
 from . import prompt_parser, devices, sd_hijack
 from .shared import opts
 from comfy.sd1_clip import SD1ClipModel
-from comfy.sdxl_clip import SDXLClipModel
+from comfy.sdxl_clip import SDXLClipModel, StableCascadeClipG
 
 class PromptChunk:
     """
@@ -289,7 +289,8 @@ class FrozenCLIPEmbedderWithCustomWordsBase(torch.nn.Module):
             zk = z * torch.abs(bm)
             zv = z * bm
 
-        z = torch.cat((zk,zv), -1).view(zk.shape[0], -1, zk.shape[2])
+        # Stable Cascade doesn't support model patching (and therefore negpip) yet
+        z = torch.cat((zk,zv), -1).view(zk.shape[0], -1, zk.shape[2]) if not isinstance(self.wrapped, StableCascadeClipG) else zv
         z.pooled = pooled
         return z
 

--- a/smZNodes.py
+++ b/smZNodes.py
@@ -1466,6 +1466,19 @@ def hook_for_settings_node_and_sampling():
                 model.model_options.update(model_options)
             else:
                 model.model_options = model_options
+
+            # Negpip sample hook
+            def negpip_apply(q, k, v, extra_options):
+                new_k = k[:, 0::2]
+                new_v = v[:, 1::2]
+                return q, new_k, new_v
+
+            try:
+                if negpip_apply.__class__ not in map(lambda _: _.__class__, model.model_options['transformer_options']['patches']['attn2_patch']):
+                    model.set_model_attn2_patch(negpip_apply)
+            except KeyError:
+                model.set_model_attn2_patch(negpip_apply)
+
             return _sample(*args, **kwargs)
 
         class Sampler(_Sampler):
@@ -1509,6 +1522,67 @@ def hook_for_dtype_unet():
             return dtype
         comfy.model_management.unet_dtype = unet_dtype
 
+# Hook to make negpip work with the default comfyui parser
+def hook_for_negpip_clip():
+    if hasattr(comfy.sd1_clip, 'gen_empty_tokens') and hasattr(comfy.sd1_clip, 'ClipTokenWeightEncoder'):
+        from comfy.sd1_clip import gen_empty_tokens, ClipTokenWeightEncoder
+
+        device = model_management.intermediate_device() if hasattr(model_management, 'intermediate_device') else torch.device('cpu')
+
+        # Copied from https://github.com/laksjdjf/cd-tuner_negpip-ComfyUI/blob/938b838546cf774dc8841000996552cef52cccf3/negpip.py#L43
+        def encode_token_weights(_self, token_weight_pairs):
+            to_encode = list()
+            max_token_len = 0
+            has_weights = False
+            for x in token_weight_pairs:
+                tokens = list(map(lambda a: a[0], x))
+                max_token_len = max(len(tokens), max_token_len)
+                has_weights = has_weights or not all(map(lambda a: a[1] == 1.0, x))
+                to_encode.append(tokens)
+
+            sections = len(to_encode)
+            if has_weights or sections == 0:
+                to_encode.append(gen_empty_tokens(_self.special_tokens, max_token_len))
+
+            out, pooled = _self.encode(to_encode)
+            if pooled is not None:
+                first_pooled = pooled[0:1].to(device)
+            else:
+                first_pooled = pooled
+
+            output = []
+            for k in range(0, sections):
+                zk = out[k:k+1].clone()
+                zv = out[k:k+1].clone()
+                if has_weights:
+                    z_empty = out[-1]
+                    for i in range(len(zk)):
+                        for j in range(len(zk[i])):
+                            weight = token_weight_pairs[k][j][1]
+                            if weight != 1.0:
+                                if weight < 0:
+                                    weight = -weight
+                                    sign = -1
+                                else:
+                                    sign = 1
+                                zk[i][j] = (zk[i][j] - z_empty[j]) * weight + z_empty[j]
+                                zv[i][j] = sign * ((zv[i][j] - z_empty[j]) * weight + z_empty[j])
+
+                z = torch.zeros_like(zk).repeat(1, 2, 1)
+                for i in range(zk.shape[1]):  # 頭悪いのでfor文
+                    z[:, 2*i, :] += zk[:, i, :]
+                    z[:, 2*i+1, :] += zv[:, i, :]
+                output.append(z)
+
+            if (len(output) == 0):
+                return out[-1:].to(device), first_pooled
+            return torch.cat(output, dim=-2).to(device), first_pooled
+
+        if not hasattr(comfy.sd1_clip.ClipTokenWeightEncoder, 'encode_token_weights_orig'):
+            comfy.sd1_clip.ClipTokenWeightEncoder.encode_token_weights_orig = comfy.sd1_clip.ClipTokenWeightEncoder.encode_token_weights
+
+        comfy.sd1_clip.ClipTokenWeightEncoder.encode_token_weights = encode_token_weights
+
 def try_hook(fn):
     try:
         fn()
@@ -1520,6 +1594,7 @@ def register_hooks():
         hook_for_settings_node_and_sampling,
         hook_for_rng_orig,
         hook_for_dtype_unet,
+        hook_for_negpip_clip,
     ]
     for hook in hooks:
         try_hook(hook)

--- a/smZNodes.py
+++ b/smZNodes.py
@@ -1531,6 +1531,10 @@ def hook_for_negpip_clip():
 
         # Copied from https://github.com/laksjdjf/cd-tuner_negpip-ComfyUI/blob/938b838546cf774dc8841000996552cef52cccf3/negpip.py#L43
         def encode_token_weights(_self, token_weight_pairs):
+            # Stable Cascade doesn't support model patching (and therefore negpip) yet
+            if isinstance(_self, comfy.sdxl_clip.StableCascadeClipG):
+                return comfy.sd1_clip.ClipTokenWeightEncoder.encode_token_weights_orig(_self, token_weight_pairs)
+
             to_encode = list()
             max_token_len = 0
             has_weights = False


### PR DESCRIPTION
Should resolve #12 and kinda resolves #28 (incorporates functionality from negpip node but still makes it incompatible)

Based on https://github.com/laksjdjf/cd-tuner_negpip-ComfyUI
Makes it possible to use negative weights in prompts.
Since patching attn2 is required for negpip to work, it's necessary to hook into default `sd1_clip.ClipTokenWeightEncoder.encode_token_weights` function.

Without negative weights everything should work exactly the same.

Not sure if the part under `opts.prompt_mean_norm` is correct (it works for negative weights, but the means for zk and zv are different, could lead to some strange effects)